### PR TITLE
Enhancement/summary bar filetype filter

### DIFF
--- a/frontend/src/components/c-stacked-bar-chart.vue
+++ b/frontend/src/components/c-stacked-bar-chart.vue
@@ -1,10 +1,12 @@
 <template lang="pug">
 .stacked-bar-container
   .stacked-bar__contrib--bar(
-    v-for="bar in bars",
+    v-for="(bar, idx) in bars",
+    :key="idx",
     :title="bar.tooltipText",
     :style="{ width: `${bar.width}%`,\
       'background-color': bar.color }"
+     @click="$emit('bar-click', bar.tooltipText.split(':')[0].trim())"
   )
 </template>
 

--- a/frontend/src/components/c-summary-charts.vue
+++ b/frontend/src/components/c-summary-charts.vue
@@ -339,6 +339,7 @@
           .summary-chart__contrib
             c-stacked-bar-chart(
               :bars="getFileTypeContributionBars(user.fileTypeContribution, user.checkedFileTypeContribution)"
+              @bar-click="onFileTypeBarClick($event, user)"
             )
         template(v-else)
           .summary-chart__contrib(
@@ -440,6 +441,10 @@ export default defineComponent({
     optimiseTimeline: {
       type: Boolean,
       default: false,
+    },
+    user: {
+      type: Object as () => User,
+      required: true,
     },
   },
   data(): {
@@ -1050,7 +1055,11 @@ export default defineComponent({
         return '';
       }
       return blurb;
-    }
+    },
+
+    onFileTypeBarClick(fileType: string, user: User) {
+      this.$emit('filter-by-filetype', { fileType, author: user.name });
+    },
   },
 });
 </script>

--- a/frontend/src/components/c-summary-charts.vue
+++ b/frontend/src/components/c-summary-charts.vue
@@ -339,7 +339,7 @@
           .summary-chart__contrib
             c-stacked-bar-chart(
               :bars="getFileTypeContributionBars(user.fileTypeContribution, user.checkedFileTypeContribution)"
-              @bar-click="onFileTypeBarClick($event, user)"
+              @bar-click="handleFileTypeBarClick(user, repo, $event)"
             )
         template(v-else)
           .summary-chart__contrib(
@@ -441,11 +441,7 @@ export default defineComponent({
     optimiseTimeline: {
       type: Boolean,
       default: false,
-    },
-    user: {
-      type: Object as () => User,
-      required: true,
-    },
+    }
   },
   data(): {
     drags: Array<number>,
@@ -1057,8 +1053,23 @@ export default defineComponent({
       return blurb;
     },
 
-    onFileTypeBarClick(fileType: string, user: User) {
-      this.$emit('filter-by-filetype', { fileType, author: user.name });
+    handleFileTypeBarClick(user: User, repoGroup: Array<User>, fileType: string) {
+      const { minDate, maxDate } = this;
+
+      const info = {
+        minDate,
+        maxDate,
+        checkedFileTypes: [fileType],
+        author: user.name,
+        repo: user.repoName,
+        name: user.displayName,
+        isMergeGroup: this.isGroupMerged(this.getGroupName(repoGroup)),
+        location: this.getRepoLink(user),
+        files: [],
+      };
+
+      this.addSelectedTab(user.name, user.repoName, 'authorship', info.isMergeGroup);
+      this.$store.commit('updateTabAuthorshipInfo', info);
     },
   },
 });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -46,4 +46,7 @@ app.use(store);
 
 app.use(router);
 
+// Enable devtools for Vue 3 (development build)
+(app.config as any).devtools = true;
+
 app.mount('#app');

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -46,7 +46,4 @@ app.use(store);
 
 app.use(router);
 
-// Enable devtools for Vue 3 (development build)
-(app.config as any).devtools = true;
-
 app.mount('#app');


### PR DESCRIPTION
## Enhancement: Make stacked summary bars clickable
- Added click support to stacked summary bars (aka summary-chart_contrib in the HTML report from DG)

- Clicking a bar with color that corresponds to a file type updates the authorship view to show only that file type

- Reused logic from the "view author's contribution" button

https://github.com/user-attachments/assets/4b86933c-86af-42fd-8568-b3044701a72e

### Why this enhancement?
- The colored author contribution bars for different file types do nothing, but intuitively feel clickable

- This reduces steps to view filtered authorship data — no need to manually uncheck / check file type checkboxes