### PR TITLE
[#2371] Rename Gradle task frontendTest to testFrontend

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -161,4 +161,4 @@ jobs:
         sudo apt-get install libgtk2.0-0t64 libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb
 
     - name: Run frontend tests
-      run: ./gradlew frontendTest -Pci
+      run: ./gradlew testFrontend -Pci

--- a/build.gradle
+++ b/build.gradle
@@ -267,7 +267,7 @@ tasks.register('cypress', com.liferay.gradle.plugins.node.tasks.ExecutePackageMa
     args = ["run-script", "debug"]
 }
 
-tasks.register('frontendTest', com.liferay.gradle.plugins.node.tasks.ExecutePackageManagerTask) {
+tasks.register('testFrontend', com.liferay.gradle.plugins.node.tasks.ExecutePackageManagerTask) {
     description 'Executes Cypress end-to-end tests; runs in headless CI mode if the "ci" property is specified.'
     dependsOn installCypress, serveTestReportDefault, serveTestReportPortfolio
     tasks.serveTestReportDefault.mustRunAfter(installCypress)
@@ -298,7 +298,7 @@ jacocoTestReport {
         html.destination file("${buildDir}/jacocoHtml")
     }
 
-    executionData systemtest, frontendTest
+    executionData systemtest, testFrontend
 }
 
 tasks.register('coverage', JacocoReport) {
@@ -383,4 +383,4 @@ void deleteReposAddressDirectory() {
     reposDirectory.deleteDir()
 }
 
-defaultTasks 'clean', 'build', 'systemtest', 'frontendTest', 'coverage'
+defaultTasks 'clean', 'build', 'systemtest', 'testFrontend', 'coverage'

--- a/docs/dg/workflow.md
+++ b/docs/dg/workflow.md
@@ -119,7 +119,7 @@ Note that it is **compulsory** to add tests for the new front-end changes that y
 
 ### Running tests
 
-To run all tests locally, run `gradlew frontendTest`.
+To run all tests locally, run `gradlew testFrontend`.
 * Using the above command, tests are run on the CLI in a headless browser without the report being displayed.
 * To run tests in a headed browser, run `gradlew cypress` then select the test file(s) in the Cypress GUI as shown above.
 


### PR DESCRIPTION
Fixes #2371

### Proposed commit message
```
Gradle: Rename frontendTest task to testFrontend

Aligns with naming convention of other tasks like installFrontend and buildFrontend.
```

### Other information